### PR TITLE
Fix some out-of-bounds reads that caused the RRFS UPP to crash

### DIFF
--- a/sorc/ncep_post.fd/CLDRAD.f
+++ b/sorc/ncep_post.fd/CLDRAD.f
@@ -2148,7 +2148,7 @@ snow_check:   IF (QQS(I,J,L)>=QCLDmin) THEN
               CLDZ(I,J) = ceil_min + FIS(I,J)*GI ! convert back to ASL and store
               CLDZ(I,J) = max(min(CLDZ(I,J), 20000.0),0.0) !set bounds
               ! find pressure at CLDZ
-              do k=1,lm-2
+              do k=2,lm-2
                 if ( zmid(i,j,lm-k+1) >= CLDZ(i,j) ) then
                    CLDP(I,J) = pmid(i,j,lm-k+2) + (CLDZ(i,j)-zmid(i,j,lm-k+2)) &
                              *(pmid(i,j,lm-k+1)-pmid(i,j,lm-k+2) )             &

--- a/sorc/ncep_post.fd/INITPOST_NETCDF.f
+++ b/sorc/ncep_post.fd/INITPOST_NETCDF.f
@@ -697,7 +697,7 @@
       
 ! sample print point
       ii = im/2
-      jj = jm/2
+      jj = (jsta+jend)/2
       
       print *,me,'max(gdlat)=', maxval(gdlat),  &
                  'max(gdlon)=', maxval(gdlon)
@@ -944,8 +944,9 @@
             pint(i,j,l)   = pint(i,j,l-1) + dpres(i,j,l-1)
           enddo
         enddo
-        if (me == 0) print*,'sample model pint,pmid' ,ii,jj,l &
-          ,pint(ii,jj,l),pmid(ii,jj,l)
+        ! The next two lines crash.
+!        if (me == 0) print*,'sample model pint,pmid' ,ii,jj,l &
+!          ,pint(ii,jj,l),pmid(ii,jj,l)
       end do
 
 !      do l=lm,1,-1


### PR DESCRIPTION
Three bugs:

1. INITPOST_NMM JJ variable pointed to out-of-bounds index
2. INITPOST_NMM print statement accessed out-of-bounds (even after fix 1)
3. CLDRAD reading out-of-bounds due to off-by-one error: `k=1,lm-2` instead of `k=2,lm-2`

Hi, @jaymes-kenyon and @CurtisAlexander-NOAA  here are your bug fixes.