### PR TITLE
Code changes to handle case where FFG files are missing, and to handle interpolation of FFG data to rotated lat-lon grid.

### DIFF
--- a/sorc/ncep_post.fd/SURFCE.f
+++ b/sorc/ncep_post.fd/SURFCE.f
@@ -142,23 +142,20 @@
        real, allocatable, dimension(:,:,:)   :: sleet, rain, freezr, snow
 !      real,   dimension(im,jm,nalg) :: sleet, rain, freezr, snow
       real, allocatable, dimension(:,:)        :: ylat, xlon
-      real, allocatable, dimension(:)        :: msclon, msclat
 !GSD
       REAL totprcp, snowratio,t2,rainl
 
 !
-      integer NLON,NLAT,NTOT,var_scale
+      integer NLON,NLAT,NTOT
       integer I,J,IWX,ITMAXMIN,IFINCR,ISVALUE,II,JJ,                    &
               ITPREC,ITSRFC,L,LS,IVEG,LLMH,                             &
               IVG,IRTN,ISEED, icat, cnt_snowratio(10),icnt_snow_rain_mixed, &
-              NX,NY,NZ,MSCNLON,MSCNLAT,MSCNLEV,HEIGHT
+              NX,NY,NZ,MSCNLON,MSCNLAT,HEIGHT
 
       real RDTPHS,TLOW,TSFCK,QSAT,DTOP,DBOT,SNEQV,RRNUM,SFCPRS,SFCQ,    &
            RC,SFCTMP,SNCOVR,FACTRS,SOLAR, s,tk,tl,w,t2c,dlt,APE,        &
            qv,e,dwpt,dum1,dum2,dum3,dum1s,dum3s,dum21,dum216,es,        &
            RLONMIN,RLATMAX,RLAT,RLON
-
-      real*8 RDX,RDY,DLON,DLAT,LONMIN,LATMIN,LONMAX,LATMAX
 
       character(len=256) :: ffgfile
 
@@ -3674,33 +3671,23 @@
 !     thresholds
          IF (IGET(913).GT.0) THEN
             ffgfile='ffg_01h.grib2'
-            call read_grib2_head(ffgfile,nx,ny,nz,rlonmin,rlatmax,&
-               rdx,rdy)
-            var_scale=1
-            mscNlon=nx
-            mscNlat=ny
-            mscNlev=nz
-            dlon=rdx
-            dlat=rdy
-            lonMin=rlonmin
-            lonMax=lonMin+dlon*(mscNlon-1)
-            latMax=rlatmax
-            latMin=latMax-dlat*(mscNlat-1)
-            if (.not. allocated(msclon)) then
-               allocate(msclon(mscNlon))
-               allocate(msclat(mscNlat))
-               allocate(mscValue(mscNlon,mscNlat))
+            INQUIRE(FILE=ffgfile, EXIST=file_exists)
+            if (file_exists) then
+               call read_grib2_head(ffgfile,nx,ny,nz,rlonmin,rlatmax,&
+                  rdx,rdy)
+               mscNlon=nx
+               mscNlat=ny
+               if (.not. allocated(mscValue)) then
+                  allocate(mscValue(mscNlon,mscNlat))
+               endif
+               ntot = nx*ny
+               call read_grib2_sngle(ffgfile,ntot,height,mscValue)
+            else
+               write(*,*) 'WARNING: 1h FFG file not available'
+               mscValue = AVGPREC_CONT(I,J)*FLOAT(IFHR)*3600.*10000./DTQ2
             endif
-            DO i=1,mscNlon
-               msclon(i)=lonMin+(i-1)*dlon
-            ENDDO
-            DO i=1,mscNlat
-               msclat(i)=latMin+(i-1)*dlat
-            ENDDO
-            ntot = nx*ny
-            call read_grib2_sngle(ffgfile,ntot,height,mscValue)
-            write(*,*) '1H FFG MAX, MIN:', &
-                        maxval(mscValue),minval(mscValue)
+!            write(*,*) '1H FFG MAX, MIN:', &
+!                        maxval(mscValue),minval(mscValue)
             ID(1:25) = 0
             ITPREC     = NINT(TPREC)
 !mp
@@ -3766,33 +3753,23 @@
          ENDIF
          IF (IGET(914).GT.0) THEN
             ffgfile='ffg_03h.grib2'
-            call read_grib2_head(ffgfile,nx,ny,nz,rlonmin,rlatmax,&
-               rdx,rdy)
-            var_scale=1
-            mscNlon=nx
-            mscNlat=ny
-            mscNlev=nz
-            dlon=rdx
-            dlat=rdy
-            lonMin=rlonmin
-            lonMax=lonMin+dlon*(mscNlon-1)
-            latMax=rlatmax
-            latMin=latMax-dlat*(mscNlat-1)
-            if (.not. allocated(msclon)) then
-               allocate(msclon(mscNlon))
-               allocate(msclat(mscNlat))
-               allocate(mscValue(mscNlon,mscNlat))
+            INQUIRE(FILE=ffgfile, EXIST=file_exists)
+            if (file_exists) then
+               call read_grib2_head(ffgfile,nx,ny,nz,rlonmin,rlatmax,&
+                  rdx,rdy)
+               mscNlon=nx
+               mscNlat=ny
+               if (.not. allocated(mscValue)) then
+                  allocate(mscValue(mscNlon,mscNlat))
+               endif
+               ntot = nx*ny
+               call read_grib2_sngle(ffgfile,ntot,height,mscValue)
+            else
+               write(*,*) 'WARNING: 3h FFG file not available'
+               mscValue = AVGPREC_CONT(I,J)*FLOAT(IFHR)*3600.*10000./DTQ2
             endif
-            DO i=1,mscNlon
-               msclon(i)=lonMin+(i-1)*dlon
-            ENDDO
-            DO i=1,mscNlat
-               msclat(i)=latMin+(i-1)*dlat
-            ENDDO
-            ntot = nx*ny
-            call read_grib2_sngle(ffgfile,ntot,height,mscValue)
-            write(*,*) '3H FFG MAX, MIN:', &
-                        maxval(mscValue),minval(mscValue)
+!            write(*,*) '3H FFG MAX, MIN:', &
+!                        maxval(mscValue),minval(mscValue)
             ID(1:25) = 0
             ITPREC     = NINT(TPREC)
 !mp
@@ -3851,33 +3828,23 @@
          ENDIF
          IF (IGET(915).GT.0) THEN
             ffgfile='ffg_06h.grib2'
-            call read_grib2_head(ffgfile,nx,ny,nz,rlonmin,rlatmax,&
-               rdx,rdy)
-            var_scale=1
-            mscNlon=nx
-            mscNlat=ny
-            mscNlev=nz
-            dlon=rdx
-            dlat=rdy
-            lonMin=rlonmin
-            lonMax=lonMin+dlon*(mscNlon-1)
-            latMax=rlatmax
-            latMin=latMax-dlat*(mscNlat-1)
-            if (.not. allocated(msclon)) then
-               allocate(msclon(mscNlon))
-               allocate(msclat(mscNlat))
-               allocate(mscValue(mscNlon,mscNlat))
+            INQUIRE(FILE=ffgfile, EXIST=file_exists)
+            if (file_exists) then
+               call read_grib2_head(ffgfile,nx,ny,nz,rlonmin,rlatmax,&
+                  rdx,rdy)
+               mscNlon=nx
+               mscNlat=ny
+               if (.not. allocated(mscValue)) then
+                  allocate(mscValue(mscNlon,mscNlat))
+               endif
+               ntot = nx*ny
+               call read_grib2_sngle(ffgfile,ntot,height,mscValue)
+            else
+               write(*,*) 'WARNING: 6h FFG file not available'
+               mscValue = AVGPREC_CONT(I,J)*FLOAT(IFHR)*3600.*10000./DTQ2
             endif
-            DO i=1,mscNlon
-              msclon(i)=lonMin+(i-1)*dlon
-            ENDDO
-            DO i=1,mscNlat
-              msclat(i)=latMin+(i-1)*dlat
-            ENDDO
-            ntot = nx*ny
-            call read_grib2_sngle(ffgfile,ntot,height,mscValue)
-            write(*,*) '6H FFG MAX, MIN:', &
-                        maxval(mscValue),minval(mscValue)
+!            write(*,*) '6H FFG MAX, MIN:', &
+!                        maxval(mscValue),minval(mscValue)
             ID(1:25) = 0
             ITPREC     = NINT(TPREC)
 !mp
@@ -3935,33 +3902,23 @@
          ENDIF
          IF (IGET(916).GT.0) THEN
             ffgfile='ffg_12h.grib2'
-            call read_grib2_head(ffgfile,nx,ny,nz,rlonmin,rlatmax,&
-               rdx,rdy)
-            var_scale=1
-            mscNlon=nx
-            mscNlat=ny
-            mscNlev=nz
-            dlon=rdx
-            dlat=rdy
-            lonMin=rlonmin
-            lonMax=lonMin+dlon*(mscNlon-1)
-            latMax=rlatmax
-            latMin=latMax-dlat*(mscNlat-1)
-            if (.not. allocated(msclon)) then
-               allocate(msclon(mscNlon))
-               allocate(msclat(mscNlat))
-               allocate(mscValue(mscNlon,mscNlat))
+            INQUIRE(FILE=ffgfile, EXIST=file_exists)
+            if (file_exists) then
+               call read_grib2_head(ffgfile,nx,ny,nz,rlonmin,rlatmax,&
+                  rdx,rdy)
+               mscNlon=nx
+               mscNlat=ny
+               if (.not. allocated(mscValue)) then
+                  allocate(mscValue(mscNlon,mscNlat))
+               endif
+               ntot = nx*ny
+               call read_grib2_sngle(ffgfile,ntot,height,mscValue)
+            else
+               write(*,*) 'WARNING: 12h FFG file not available'
+               mscValue = AVGPREC_CONT(I,J)*FLOAT(IFHR)*3600.*10000./DTQ2
             endif
-            DO i=1,mscNlon
-              msclon(i)=lonMin+(i-1)*dlon
-            ENDDO
-            DO i=1,mscNlat
-              msclat(i)=latMin+(i-1)*dlat
-            ENDDO
-            ntot = nx*ny
-            call read_grib2_sngle(ffgfile,ntot,height,mscValue)
-            write(*,*) '12H FFG MAX, MIN:', &
-                        maxval(mscValue),minval(mscValue)
+!            write(*,*) '12H FFG MAX, MIN:', &
+!                        maxval(mscValue),minval(mscValue)
             ID(1:25) = 0
             ITPREC     = NINT(TPREC)
 !mp

--- a/sorc/ncep_post.fd/SURFCE.f
+++ b/sorc/ncep_post.fd/SURFCE.f
@@ -155,9 +155,13 @@
       real RDTPHS,TLOW,TSFCK,QSAT,DTOP,DBOT,SNEQV,RRNUM,SFCPRS,SFCQ,    &
            RC,SFCTMP,SNCOVR,FACTRS,SOLAR, s,tk,tl,w,t2c,dlt,APE,        &
            qv,e,dwpt,dum1,dum2,dum3,dum1s,dum3s,dum21,dum216,es,        &
-           RLONMIN,RLATMAX,RLAT,RLON
+           RLONMIN,RLATMAX
+
+      real*8 RDX,RDY
 
       character(len=256) :: ffgfile
+
+      logical file_exists
 
       logical, parameter :: debugprint = .false.
 

--- a/sorc/ncep_post.fd/grib2_module.f
+++ b/sorc/ncep_post.fd/grib2_module.f
@@ -1106,6 +1106,17 @@
 !                write(*,*) 'nx,ny=',nx,ny
 !                write(*,*) 'dx,dy=',rdx,rdy
 !                write(*,*) 'lat1,lon1=',rlatmax,rlonmin
+             else if (gfld%igdtnum.eq.1) then ! Rotated Lat Lon Grid (RRFS_NA)
+                nx = gfld%igdtmpl(8)
+                ny = gfld%igdtmpl(9)
+                nz = 1
+                rdx = gfld%igdtmpl(17)/scale_factor
+                rdy = gfld%igdtmpl(18)/scale_factor
+                rlatmax = gfld%igdtmpl(12)/scale_factor
+                rlonmin = gfld%igdtmpl(13)/scale_factor
+!                write(*,*) 'nx,ny=',nx,ny
+!                write(*,*) 'dx,dy=',rdx,rdy
+!                write(*,*) 'lat1,lon1=',rlatmax,rlonmin
              else if (gfld%igdtnum.eq.30) then ! Lambert Conformal Grid (HRRR)
                 nx = gfld%igdtmpl(8)
                 ny = gfld%igdtmpl(9)
@@ -1249,6 +1260,16 @@
 !                write(*,*) 'nx,ny=',nx,ny
 !                write(*,*) 'dx,dy=',dx,dy
 !                write(*,*) 'lat1,lon1=',lat1,lon1
+             else if (gfld%igdtnum.eq.1) then ! Rotated Lat Lon Grid (RRFS_NA)
+                nx = gfld%igdtmpl(8)
+                ny = gfld%igdtmpl(9)
+                dx = gfld%igdtmpl(17)/scale_factor
+                dy = gfld%igdtmpl(18)/scale_factor
+                lat1 = gfld%igdtmpl(12)/scale_factor
+                lon1 = gfld%igdtmpl(13)/scale_factor
+!                write(*,*) 'nx,ny=',nx,ny
+!                write(*,*) 'dx,dy=',rdx,rdy
+!                write(*,*) 'lat1,lon1=',rlatmax,rlonmin
              else if (gfld%igdtnum.eq.30) then ! Lambert Conformal Grid (HRRR)
                 nx = gfld%igdtmpl(8)
                 ny = gfld%igdtmpl(9)


### PR DESCRIPTION
These changes are needed to allow UPP to run through and not crash when FFG files are not present (i.e., on every system except Jet).  There are also changes to grib2_module.f to allow interpolation of FFG data to 3km NA rotated lat-lon grid.  I also did some minor code cleanup in SURFCE.f to remove unused variables.

Code was tested with realtime RRFS nc files on Jet.