### PR TITLE
GRIB2 encoding fix for 6 variables in RRFS

### DIFF
--- a/sorc/ncep_post.fd/SURFCE.f
+++ b/sorc/ncep_post.fd/SURFCE.f
@@ -824,8 +824,12 @@
         if(grib=='grib2') then
           cfld=cfld+1
           fld_info(cfld)%ifld=IAVBLFLD(IGET(502))
-          fld_info(cfld)%ntrange=IFHR-ID(18)
-          fld_info(cfld)%tinvstat=1
+          if(ITSRFC>0) then
+            fld_info(cfld)%ntrange=1
+          else
+            fld_info(cfld)%ntrange=0
+          endif
+          fld_info(cfld)%tinvstat=IFHR-ID(18)
 !$omp parallel do private(i,j,jj)
           do j=1,jend-jsta+1
             jj = jsta+j-1
@@ -2313,12 +2317,6 @@
          if(grib=='grib2') then
            cfld=cfld+1
            fld_info(cfld)%ifld=IAVBLFLD(IGET(505))
-           if(ITSRFC>0) then
-            fld_info(cfld)%ntrange=1
-           else
-            fld_info(cfld)%ntrange=0
-           endif
-           fld_info(cfld)%tinvstat=IFHR-ID(18)
 !$omp parallel do private(i,j,jj)
            do j=1,jend-jsta+1
              jj = jsta+j-1

--- a/sorc/ncep_post.fd/SURFCE.f
+++ b/sorc/ncep_post.fd/SURFCE.f
@@ -6333,7 +6333,7 @@
             ID(20)     = 3
          if(grib=='grib2') then
             cfld=cfld+1
-            fld_info(cfld)%ifld=IAVBLFLD(IGET(500))
+            fld_info(cfld)%ifld=IAVBLFLD(IGET(504))
             if(ITSRFC>0) then
               fld_info(cfld)%ntrange=1
             else

--- a/sorc/ncep_post.fd/SURFCE.f
+++ b/sorc/ncep_post.fd/SURFCE.f
@@ -791,8 +791,12 @@
         if(grib=='grib2') then
           cfld=cfld+1
           fld_info(cfld)%ifld=IAVBLFLD(IGET(501))
-          fld_info(cfld)%ntrange=IFHR-ID(18)
-          fld_info(cfld)%tinvstat=1
+          if(ITSRFC>0) then
+            fld_info(cfld)%ntrange=1
+          else
+            fld_info(cfld)%ntrange=0
+          endif
+          fld_info(cfld)%tinvstat=IFHR-ID(18)
 !$omp parallel do private(i,j,jj)
           do j=1,jend-jsta+1
             jj = jsta+j-1
@@ -2242,8 +2246,12 @@
            if(grib=='grib2') then
             cfld=cfld+1
             fld_info(cfld)%ifld=IAVBLFLD(IGET(506))
-            fld_info(cfld)%ntrange=IFHR-ID(18)
-            fld_info(cfld)%tinvstat=1
+            if(ITSRFC>0) then
+              fld_info(cfld)%ntrange=1
+            else
+              fld_info(cfld)%ntrange=0
+            endif
+            fld_info(cfld)%tinvstat=IFHR-ID(18)
 !$omp parallel do private(i,j,jj)
             do j=1,jend-jsta+1
               jj = jsta+j-1
@@ -2253,8 +2261,12 @@
             enddo
             cfld=cfld+1
             fld_info(cfld)%ifld=IAVBLFLD(IGET(507))
-            fld_info(cfld)%ntrange=IFHR-ID(18)
-            fld_info(cfld)%tinvstat=1
+            if(ITSRFC>0) then
+              fld_info(cfld)%ntrange=1
+            else
+              fld_info(cfld)%ntrange=0
+            endif
+            fld_info(cfld)%tinvstat=IFHR-ID(18)
 !$omp parallel do private(i,j,jj)
             do j=1,jend-jsta+1
               jj = jsta+j-1
@@ -2301,6 +2313,12 @@
          if(grib=='grib2') then
            cfld=cfld+1
            fld_info(cfld)%ifld=IAVBLFLD(IGET(505))
+           if(ITSRFC>0) then
+            fld_info(cfld)%ntrange=1
+           else
+            fld_info(cfld)%ntrange=0
+           endif
+           fld_info(cfld)%tinvstat=IFHR-ID(18)
 !$omp parallel do private(i,j,jj)
            do j=1,jend-jsta+1
              jj = jsta+j-1
@@ -6289,8 +6307,12 @@
          if(grib=='grib2') then
             cfld=cfld+1
             fld_info(cfld)%ifld=IAVBLFLD(IGET(503))
-            fld_info(cfld)%ntrange=IFHR-ID(18)
-            fld_info(cfld)%tinvstat=1
+            if(ITSRFC>0) then
+              fld_info(cfld)%ntrange=1
+            else
+              fld_info(cfld)%ntrange=0
+            endif
+            fld_info(cfld)%tinvstat=IFHR-ID(18)
             datapd(1:im,1:jend-jsta+1,cfld)=GRID1(1:im,jsta:jend)
          endif
       ENDIF
@@ -6313,9 +6335,13 @@
             ID(20)     = 3
          if(grib=='grib2') then
             cfld=cfld+1
-            fld_info(cfld)%ifld=IAVBLFLD(IGET(504))
-            fld_info(cfld)%ntrange=IFHR-ID(18)
-            fld_info(cfld)%tinvstat=1
+            fld_info(cfld)%ifld=IAVBLFLD(IGET(500))
+            if(ITSRFC>0) then
+              fld_info(cfld)%ntrange=1
+            else
+              fld_info(cfld)%ntrange=0
+            endif
+            fld_info(cfld)%tinvstat=IFHR-ID(18)
             datapd(1:im,1:jend-jsta+1,cfld)=GRID1(1:im,jsta:jend)
          endif
 


### PR DESCRIPTION
This PR corrects the GRIB2 encoding for the following six variables in RRFS bgrd3df000 files:

1206:PRES:surface
1207:TMP:10m
1223:MAXUW:10m
1224:MAXVW:10m
1266:AKHS:surface
1267:AKMS:surface

These previously were missing the "n" parameter, leading to this error message with recent versions of wgrib2:

** WARNING bad grib message: Statistical Processing bad n=0 **

The change was tested with some realtime RRFS_NA_3km netcdf files on Jet.  
