### PR TITLE
Implement UPP smoothing for some fields

### DIFF
--- a/sorc/ncep_post.fd/INITPOST_NETCDF.f
+++ b/sorc/ncep_post.fd/INITPOST_NETCDF.f
@@ -79,7 +79,7 @@
               ardsw, asrfc, avrain, avcnvc, theat, gdsdegr, spl, lsm, alsl, im, jm, im_jm, lm,  &
               jsta_2l, jend_2u, nsoil, lp1, icu_physics, ivegsrc, novegtype, nbin_ss, nbin_bc,  &
               nbin_oc, nbin_su, gocart_on, pt_tbl, hyb_sigp, filenameFlux, fileNameAER,         &
-              iSF_SURFACE_PHYSICS,rdaod, aqfcmaq_on
+              iSF_SURFACE_PHYSICS,rdaod, aqfcmaq_on, modelname, smflag
       use gridspec_mod, only: maptype, gridtype, latstart, latlast, lonstart, lonlast, cenlon,  &
               dxval, dyval, truelat2, truelat1, psmapf, cenlat,lonstartv, lonlastv, cenlonv,    &
               latstartv, latlastv, cenlatv,latstart_r,latlast_r,lonstart_r,lonlast_r, STANDLON
@@ -3496,6 +3496,13 @@
 
 !       write(6,*)'lonstart,lonlast A calling bcast=',lonstart,lonlast
 !
+
+!tgs Define smoothing flag for isobaric output 
+              IF(MODELNAME == 'RAPR' .OR. MODELNAME == 'FV3R')THEN
+                SMFLAG=.TRUE.
+              ELSE
+                SMFLAG=.FALSE.
+              ENDIF
 
 ! generate look up table for lifted parcel calculations
 

--- a/sorc/ncep_post.fd/MAPSSLP.f
+++ b/sorc/ncep_post.fd/MAPSSLP.f
@@ -59,9 +59,9 @@
 
 
 ! smooth 700 mb temperature first
-       if(MAPTYPE==6) then
+       if(MAPTYPE==6 .OR. MAPTYPE == 207) then
          if(grib=='grib2') then
-            dxm=(DXVAL / 360.)*(ERAD*2.*pi)/1.d6  ! [mm]
+            dxm=(DXVAL / 360.)*(ERAD*2.*pi)/1000.0  ! [mm]
          endif
        else
          dxm = dxval

--- a/sorc/ncep_post.fd/MDL2P.f
+++ b/sorc/ncep_post.fd/MDL2P.f
@@ -1109,9 +1109,9 @@
 
                   IF (SMFLAG) THEN
 !tgs - smoothing of geopotential heights
-                    if(MAPTYPE == 6) then
+                    if(MAPTYPE == 6 .OR. MAPTYPE == 207) then
                       if(grib=='grib2') then
-                        dxm = (DXVAL / 360.)*(ERAD*2.*pi)/1.d6  ! [mm]
+                        dxm = (DXVAL / 360.)*(ERAD*2.*pi)/1000.0  ! [mm]
                       endif
                     else
                       dxm = dxval

--- a/sorc/ncep_post.fd/SMOOTH.f
+++ b/sorc/ncep_post.fd/SMOOTH.f
@@ -73,28 +73,44 @@
          IF (J > 2) then
 !$omp parallel do private(i)
            DO I=2,IX-1
-             FIELD(I,J-1) = HOLD(I,I2)
+             IF (HOLD(I,I2) < 9E10) THEN
+               FIELD(I,J-1) = HOLD(I,I2)
+             ENDIF
            ENDDO
          endif
        ENDDO
 
 !$omp parallel do private(i)
        DO I = 2,IX-1
-         FIELD (I,IY-1) = HOLD(I,I1)
+         IF (HOLD(I,I1) < 9E10) THEN
+           FIELD (I,IY-1) = HOLD(I,I1)
+         ENDIF
        ENDDO
 
        DO I = 2,IX-1
-         FIELD(I,1)  = SMTH4 * FIELD(I,1)                             &
-                     + SMTH5 * (FIELD(I-1,1) + FIELD(I+1,1))
-         FIELD(I,IY) = SMTH4 * FIELD(I,IY)                            &
+         IF (FIELD(I,1) < 9E10 .AND. FIELD(I-1,1) < 9E10 .AND.        &
+             FIELD(I+1,1) < 9E10) THEN
+           FIELD(I,1)  = SMTH4 * FIELD(I,1)                           &
+                       + SMTH5 * (FIELD(I-1,1) + FIELD(I+1,1))
+         ENDIF
+         IF (FIELD(I,IY) < 9E10 .AND. FIELD(I-1,IY) < 9E10 .AND.      &
+             FIELD(I+1,IY) < 9E10) THEN
+           FIELD(I,IY) = SMTH4 * FIELD(I,IY)                          &
                      + SMTH5 * (FIELD(I-1,IY) + FIELD(I+1,IY))
+         ENDIF
        ENDDO
 
        DO J = 2,IY-1
-         FIELD(1,J)  = SMTH4 * FIELD(1,J)                             &
-                     + SMTH5 * (FIELD(1,J-1) + FIELD(1,J+1))
-         FIELD(IX,J) = SMTH4 * FIELD(IX,J)                            &
-                     + SMTH5 * (FIELD(IX,J-1) + FIELD(IX,J+1))
+         IF (FIELD(1,J) < 9E10 .AND. FIELD(1,J-1) < 9E10 .AND.        &
+             FIELD(1,J+1) < 9E10) THEN
+           FIELD(1,J)  = SMTH4 * FIELD(1,J)                           &
+                       + SMTH5 * (FIELD(1,J-1) + FIELD(1,J+1))
+         ENDIF
+         IF (FIELD(IX,J) < 9E10 .AND. FIELD(IX,J-1) < 9E10 .AND.      &
+             FIELD(IX,J+1) < 9E10) THEN
+           FIELD(IX,J) = SMTH4 * FIELD(IX,J)                            &
+                       + SMTH5 * (FIELD(IX,J-1) + FIELD(IX,J+1))
+         ENDIF
        ENDDO
 
       RETURN

--- a/sorc/ncep_post.fd/SMOOTH.f
+++ b/sorc/ncep_post.fd/SMOOTH.f
@@ -44,6 +44,7 @@
 
 !**********************************************************************
 !**********************************************************************
+      use ctlblk_mod, only: SPVAL
 
       implicit none
 
@@ -73,7 +74,7 @@
          IF (J > 2) then
 !$omp parallel do private(i)
            DO I=2,IX-1
-             IF (HOLD(I,I2) < 9E10) THEN
+             IF (HOLD(I,I2) < SPVAL) THEN
                FIELD(I,J-1) = HOLD(I,I2)
              ENDIF
            ENDDO
@@ -82,32 +83,32 @@
 
 !$omp parallel do private(i)
        DO I = 2,IX-1
-         IF (HOLD(I,I1) < 9E10) THEN
+         IF (HOLD(I,I1) < SPVAL) THEN
            FIELD (I,IY-1) = HOLD(I,I1)
          ENDIF
        ENDDO
 
        DO I = 2,IX-1
-         IF (FIELD(I,1) < 9E10 .AND. FIELD(I-1,1) < 9E10 .AND.        &
-             FIELD(I+1,1) < 9E10) THEN
+         IF (FIELD(I,1) < SPVAL .AND. FIELD(I-1,1) < SPVAL .AND.        &
+             FIELD(I+1,1) < SPVAL) THEN
            FIELD(I,1)  = SMTH4 * FIELD(I,1)                           &
                        + SMTH5 * (FIELD(I-1,1) + FIELD(I+1,1))
          ENDIF
-         IF (FIELD(I,IY) < 9E10 .AND. FIELD(I-1,IY) < 9E10 .AND.      &
-             FIELD(I+1,IY) < 9E10) THEN
+         IF (FIELD(I,IY) < SPVAL .AND. FIELD(I-1,IY) < SPVAL .AND.      &
+             FIELD(I+1,IY) < SPVAL) THEN
            FIELD(I,IY) = SMTH4 * FIELD(I,IY)                          &
                      + SMTH5 * (FIELD(I-1,IY) + FIELD(I+1,IY))
          ENDIF
        ENDDO
 
        DO J = 2,IY-1
-         IF (FIELD(1,J) < 9E10 .AND. FIELD(1,J-1) < 9E10 .AND.        &
-             FIELD(1,J+1) < 9E10) THEN
+         IF (FIELD(1,J) < SPVAL .AND. FIELD(1,J-1) < SPVAL .AND.        &
+             FIELD(1,J+1) < SPVAL) THEN
            FIELD(1,J)  = SMTH4 * FIELD(1,J)                           &
                        + SMTH5 * (FIELD(1,J-1) + FIELD(1,J+1))
          ENDIF
-         IF (FIELD(IX,J) < 9E10 .AND. FIELD(IX,J-1) < 9E10 .AND.      &
-             FIELD(IX,J+1) < 9E10) THEN
+         IF (FIELD(IX,J) < SPVAL .AND. FIELD(IX,J-1) < SPVAL .AND.      &
+             FIELD(IX,J+1) < SPVAL) THEN
            FIELD(IX,J) = SMTH4 * FIELD(IX,J)                            &
                        + SMTH5 * (FIELD(IX,J-1) + FIELD(IX,J+1))
          ENDIF

--- a/sorc/ncep_post.fd/SMOOTH.f
+++ b/sorc/ncep_post.fd/SMOOTH.f
@@ -44,7 +44,6 @@
 
 !**********************************************************************
 !**********************************************************************
-      use ctlblk_mod, only: SPVAL
 
       implicit none
 
@@ -74,7 +73,7 @@
          IF (J > 2) then
 !$omp parallel do private(i)
            DO I=2,IX-1
-             IF (HOLD(I,I2) < SPVAL) THEN
+             IF (HOLD(I,I2) < 9E10) THEN
                FIELD(I,J-1) = HOLD(I,I2)
              ENDIF
            ENDDO
@@ -83,32 +82,32 @@
 
 !$omp parallel do private(i)
        DO I = 2,IX-1
-         IF (HOLD(I,I1) < SPVAL) THEN
+         IF (HOLD(I,I1) < 9E10) THEN
            FIELD (I,IY-1) = HOLD(I,I1)
          ENDIF
        ENDDO
 
        DO I = 2,IX-1
-         IF (FIELD(I,1) < SPVAL .AND. FIELD(I-1,1) < SPVAL .AND.        &
-             FIELD(I+1,1) < SPVAL) THEN
+         IF (FIELD(I,1) < 9E10 .AND. FIELD(I-1,1) < 9E10 .AND.        &
+             FIELD(I+1,1) < 9E10) THEN
            FIELD(I,1)  = SMTH4 * FIELD(I,1)                           &
                        + SMTH5 * (FIELD(I-1,1) + FIELD(I+1,1))
          ENDIF
-         IF (FIELD(I,IY) < SPVAL .AND. FIELD(I-1,IY) < SPVAL .AND.      &
-             FIELD(I+1,IY) < SPVAL) THEN
+         IF (FIELD(I,IY) < 9E10 .AND. FIELD(I-1,IY) < 9E10 .AND.      &
+             FIELD(I+1,IY) < 9E10) THEN
            FIELD(I,IY) = SMTH4 * FIELD(I,IY)                          &
                      + SMTH5 * (FIELD(I-1,IY) + FIELD(I+1,IY))
          ENDIF
        ENDDO
 
        DO J = 2,IY-1
-         IF (FIELD(1,J) < SPVAL .AND. FIELD(1,J-1) < SPVAL .AND.        &
-             FIELD(1,J+1) < SPVAL) THEN
+         IF (FIELD(1,J) < 9E10 .AND. FIELD(1,J-1) < 9E10 .AND.        &
+             FIELD(1,J+1) < 9E10) THEN
            FIELD(1,J)  = SMTH4 * FIELD(1,J)                           &
                        + SMTH5 * (FIELD(1,J-1) + FIELD(1,J+1))
          ENDIF
-         IF (FIELD(IX,J) < SPVAL .AND. FIELD(IX,J-1) < SPVAL .AND.      &
-             FIELD(IX,J+1) < SPVAL) THEN
+         IF (FIELD(IX,J) < 9E10 .AND. FIELD(IX,J-1) < 9E10 .AND.      &
+             FIELD(IX,J+1) < 9E10) THEN
            FIELD(IX,J) = SMTH4 * FIELD(IX,J)                            &
                        + SMTH5 * (FIELD(IX,J-1) + FIELD(IX,J+1))
          ENDIF


### PR DESCRIPTION
This PR implements smoothing for several fields, consistent with what was applied in RAP/HRRR.  Fields smoothed include:

HGT on isobaric surfaces
TMP on isobaric surfaces
RH on isobaric surfaces
VVEL on isobaric surfaces
UGRD on isobaric surfaces
VGRD on isobaric surfaces
ABSV on isobaric surfaces
PRMSL

Note that this smoothing leads to a near doubling of the UPP run time for the RRFS NA 3km domain, from ~4.5 min to ~8.5 min (with currently used 6 cores).  