### PR TITLE
Adding soil moisture availability / "wetness" to output for RRFS

### DIFF
--- a/sorc/ncep_post.fd/INITPOST_NETCDF.f
+++ b/sorc/ncep_post.fd/INITPOST_NETCDF.f
@@ -3073,7 +3073,7 @@
 !$omp parallel do private(i,j)
         do j=jsta,jend
           do i=1,im
-            smstav(i,j) = 0.01*buf(i,j)
+            smstav(i,j) = buf(i,j)
           enddo
         enddo
 !$omp parallel do private(i,j)

--- a/sorc/ncep_post.fd/INITPOST_NETCDF.f
+++ b/sorc/ncep_post.fd/INITPOST_NETCDF.f
@@ -3067,7 +3067,7 @@
 !     if(debugprint)print*,'sample l',VarName,' = ',1,isltyp(isa,jsa)
       
       IF(MODELNAME == 'FV3R')THEN
-        VarName='wetness'
+        VarName='wet1'
         call read_netcdf_2d_scatter(me,ncid2d,1,im,jm,jsta,jsta_2l &
          ,jend_2u,MPI_COMM_COMP,icnt,idsp,spval,VarName,buf)
 !$omp parallel do private(i,j)

--- a/sorc/ncep_post.fd/INITPOST_NETCDF.f
+++ b/sorc/ncep_post.fd/INITPOST_NETCDF.f
@@ -3066,21 +3066,47 @@
       enddo
 !     if(debugprint)print*,'sample l',VarName,' = ',1,isltyp(isa,jsa)
       
+      IF(MODELNAME == 'FV3R')THEN
+        VarName='wetness'
+        call read_netcdf_2d_scatter(me,ncid2d,1,im,jm,jsta,jsta_2l &
+         ,jend_2u,MPI_COMM_COMP,icnt,idsp,spval,VarName,buf)
 !$omp parallel do private(i,j)
-      do j=jsta_2l,jend_2u
-        do i=1,im
-          smstav(i,j) = spval    ! GFS does not have soil moisture availability
-!          smstot(i,j) = spval    ! GFS does not have total soil moisture
-          sfcevp(i,j) = spval    ! GFS does not have accumulated surface evaporation
-          acsnow(i,j) = spval    ! GFS does not have averaged accumulated snow
-          acsnom(i,j) = spval    ! GFS does not have snow melt
-!          sst(i,j)    = spval    ! GFS does not have sst????
-          thz0(i,j)   = ths(i,j) ! GFS does not have THZ0, use THS to substitute
-          qz0(i,j)    = spval    ! GFS does not output humidity at roughness length
-          uz0(i,j)    = spval    ! GFS does not output u at roughness length
-          vz0(i,j)    = spval    ! GFS does not output humidity at roughness length
+        do j=jsta,jend
+          do i=1,im
+            smstav(i,j) = 0.01*buf(i,j)
+          enddo
+        enddo
+!$omp parallel do private(i,j)
+        do j=jsta_2l,jend_2u
+          do i=1,im
+!            smstot(i,j) = spval    ! GFS does not have total soil moisture
+            sfcevp(i,j) = spval    ! GFS does not have accumulated surface evaporation
+            acsnow(i,j) = spval    ! GFS does not have averaged accumulated snow
+            acsnom(i,j) = spval    ! GFS does not have snow melt
+!            sst(i,j)    = spval    ! GFS does not have sst????
+            thz0(i,j)   = ths(i,j) ! GFS does not have THZ0, use THS to substitute
+            qz0(i,j)    = spval    ! GFS does not output humidity at roughness length
+            uz0(i,j)    = spval    ! GFS does not output u at roughness length
+            vz0(i,j)    = spval    ! GFS does not output humidity at roughness length
         enddo
       enddo
+      ELSE
+!$omp parallel do private(i,j)
+        do j=jsta_2l,jend_2u
+          do i=1,im
+            smstav(i,j) = spval    ! GFS does not have soil moisture availability
+!            smstot(i,j) = spval    ! GFS does not have total soil moisture
+            sfcevp(i,j) = spval    ! GFS does not have accumulated surface evaporation
+            acsnow(i,j) = spval    ! GFS does not have averaged accumulated snow
+            acsnom(i,j) = spval    ! GFS does not have snow melt
+!            sst(i,j)    = spval    ! GFS does not have sst????
+            thz0(i,j)   = ths(i,j) ! GFS does not have THZ0, use THS to substitute
+            qz0(i,j)    = spval    ! GFS does not output humidity at roughness length
+            uz0(i,j)    = spval    ! GFS does not output u at roughness length
+            vz0(i,j)    = spval    ! GFS does not output humidity at roughness length
+          enddo
+        enddo
+      END IF
       do l=1,lm
 !$omp parallel do private(i,j)
         do j=jsta_2l,jend_2u


### PR DESCRIPTION
Modifying INITPOST_NETCDF.f to allow passing through soil moisture availability in RRFS (FV3R).  Previously the code set it all to missing.  This variable is needed for the calculation of the hourly wildfire potential.  

The code change was tested for the RRFS_NA_3km domain on Jet, and works both when "wetness" is available in the phyf*.nc files and when it is not available.  