### PR TITLE
Adding a check for extremely large positive or negative UH values

### DIFF
--- a/sorc/ncep_post.fd/CALUPDHEL.f
+++ b/sorc/ncep_post.fd/CALUPDHEL.f
@@ -131,11 +131,14 @@
 
               UPDHEL(I,J)=UPDHEL(I,J)+(DVDX-DUDY)*WH(I,J,L)*DZ
 
+              IF (UPDHEL(I,J) < -9E10 .OR. UPDHEL(I,J) > 9E10) THEN
+                 UPDHEL(I,J) = spval
+              ENDIF
+
             ENDIF
           ENDDO l_loop
         ENDDO
       ENDDO
-
 !
 !      print*,'jsta_m, jend_m in calupdhel= ',jsta_m,jend_m
 !     


### PR DESCRIPTION
Updraft helicity values of +/- Infinity sometimes show up in UPP, which causes a crash when the GRIB2 field is written out.  This code change adds a check to set these huge numbers to missing values.  The cause of the error still needs to be determined, but this PR will fix the crash.  The error comes from DDVDX and DDUDX in UPP_MATH.f being sometimes set to +/-Inf.

This was tested on Jet in retrospective mode for a 13-km NA RRFS case.