### PR TITLE
Fix for 0-h GRIB2 encoding

### DIFF
--- a/sorc/ncep_post.fd/SURFCE.f
+++ b/sorc/ncep_post.fd/SURFCE.f
@@ -2559,6 +2559,12 @@
          if(grib=='grib2') then
            cfld=cfld+1
            fld_info(cfld)%ifld=IAVBLFLD(IGET(167))
+           if(ITSRFC>0) then
+             fld_info(cfld)%ntrange=1
+           else
+             fld_info(cfld)%ntrange=0
+           endif
+           fld_info(cfld)%tinvstat=IFHR-ID(18)
 !$omp parallel do private(i,j,jj)
            do j=1,jend-jsta+1
              jj = jsta+j-1

--- a/sorc/ncep_post.fd/SURFCE.f
+++ b/sorc/ncep_post.fd/SURFCE.f
@@ -2559,12 +2559,6 @@
          if(grib=='grib2') then
            cfld=cfld+1
            fld_info(cfld)%ifld=IAVBLFLD(IGET(167))
-           if(ITSRFC>0) then
-             fld_info(cfld)%ntrange=1
-           else
-             fld_info(cfld)%ntrange=0
-           endif
-           fld_info(cfld)%tinvstat=IFHR-ID(18)
 !$omp parallel do private(i,j,jj)
            do j=1,jend-jsta+1
              jj = jsta+j-1
@@ -2588,12 +2582,12 @@
            cfld=cfld+1
            fld_info(cfld)%ifld=IAVBLFLD(IGET(508))
            fld_info(cfld)%lvl=LVLSXML(1,IGET(508))
-           fld_info(cfld)%tinvstat=1
-           if (IFHR > 0) then
+           if(ITSRFC>0) then
              fld_info(cfld)%ntrange=1
            else
              fld_info(cfld)%ntrange=0
            endif
+           fld_info(cfld)%tinvstat=IFHR-ID(18)
 !$omp parallel do private(i,j,jj)
            do j=1,jend-jsta+1
              jj = jsta+j-1


### PR DESCRIPTION
Max precip rate was incorrectly encoded in GRIB2, leading to crashes with recent versions of wgrib2.  This PR fixes the problem.  

The code change was tested on Jet for the 3km NA RRFS domain.  