### PR TITLE
Bug fix for variable density snow accumulation.

### DIFF
--- a/sorc/ncep_post.fd/SURFCE.f
+++ b/sorc/ncep_post.fd/SURFCE.f
@@ -466,7 +466,7 @@
             cfld=cfld+1
             fld_info(cfld)%ifld=IAVBLFLD(IGET(725))
             fld_info(cfld)%ntrange=1
-            fld_info(cfld)%tinvstat=IFHR-ID(18)
+            fld_info(cfld)%tinvstat=IFHR
 !$omp parallel do private(i,j,ii,jj)
             do j=1,jend-jsta+1
               jj = jsta+j-1


### PR DESCRIPTION
Variable density snow was erroneously encoded as 1h accumulation, but is actually run total accumulation.  This one-line change fixes this issue.

The code was tested on Jet for the RRFS_CONUS_3km system.