### PR TITLE
Correcting units for variable density snow accumulation.

### DIFF
--- a/sorc/ncep_post.fd/SURFCE.f
+++ b/sorc/ncep_post.fd/SURFCE.f
@@ -472,7 +472,7 @@
               jj = jsta+j-1
               do i=1,iend-ista+1
               ii = ista+i-1
-                datapd(i,j,cfld) =  SNDEPAC(ii,jj)
+                datapd(i,j,cfld) =  0.001*SNDEPAC(ii,jj)
               enddo
             enddo
          endif

--- a/sorc/ncep_post.fd/SURFCE.f
+++ b/sorc/ncep_post.fd/SURFCE.f
@@ -472,7 +472,7 @@
               jj = jsta+j-1
               do i=1,iend-ista+1
               ii = ista+i-1
-                datapd(i,j,cfld) =  0.001*SNDEPAC(ii,jj)
+                datapd(i,j,cfld) =  SNDEPAC(ii,jj)/(1E3)
               enddo
             enddo
          endif


### PR DESCRIPTION
This code change corrects the units encoding for the variable density snow accumulation.  It was previously incorrectly assumed in UPP that the netCDF variable was in mm.

The code was tested on Jet for the RRFS_CONUS_3km system.