### PR TITLE
Small bug fix for VISBSN, VIS including blowing snow effect

### DIFF
--- a/parm/post_avblflds.xml
+++ b/parm/post_avblflds.xml
@@ -3862,7 +3862,7 @@
     <param>
        <post_avblfldidx>438</post_avblfldidx>
        <shortname>GSD_BLSN_ON_SURFACE</shortname>
-       <longname>GSD_visibility on surface</longname>
+       <longname>GSD_blsn on surface</longname>
        <pname>VISBSN</pname>
        <fixed_sfc1_type>surface</fixed_sfc1_type>
        <scale>6.0</scale>

--- a/parm/postxconfig-NT-fv3lam_rrfs.txt
+++ b/parm/postxconfig-NT-fv3lam_rrfs.txt
@@ -4571,7 +4571,7 @@ surface
 ?
 438
 GSD_BLSN_ON_SURFACE
-GSD_visibility on surface
+GSD_blsn on surface
 1
 tmpl4_0
 VISBSN
@@ -17500,7 +17500,7 @@ surface
 ?
 438
 GSD_BLSN_ON_SURFACE
-GSD_visibility on surface
+GSD_blsn on surface
 1
 tmpl4_0
 VISBSN

--- a/sorc/ncep_post.fd/CALVIS_GSD.f
+++ b/sorc/ncep_post.fd/CALVIS_GSD.f
@@ -321,7 +321,7 @@
 !        print *, i,j
 
 
-        if (si(i,j) .ge. 1.0) then
+        if (si(i,j)<spval .and. si(i,j) .ge. 1.0) then
             z_r = 1.6*(ustar(i,j)**2./(2.*g))
             Q_s = max((0.68/ustar(i,j))*(RHOAIR/g)*(ustar(i,j)**2.-ustar_t**2.),0.0)
             C_r = (Q_s/u_p)*(lamda*g/ustar(i,j)**2.)*exp(-lamda*z_r*g/ustar(i,j)**2.)


### PR DESCRIPTION
This PR changes the "long_name" for the visibility including the effect of blowing snow.  It needs to have a different "long_name" from the regular visibility in order to allow for python plotting.