### PR TITLE
[mpas] Update modules after lfs4 -> contrib migration.

### DIFF
--- a/modulefiles/jet.lua
+++ b/modulefiles/jet.lua
@@ -2,13 +2,16 @@ help([[
 Load environment to build UPP on Jet
 ]])
 
-prepend_path("MODULEPATH", "/mnt/lfs4/HFIP/hfv3gfs/role.epic/spack-stack/spack-stack-1.6.0/envs/upp-addon-env/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/contrib/spack-stack/spack-stack-1.6.0/envs/upp-addon-env/install/modulefiles/Core")
 
 stack_intel_ver=os.getenv("stack_intel_ver") or "2021.5.0"
 load(pathJoin("stack-intel", stack_intel_ver))
 
 stack_impi_ver=os.getenv("stack_impi_ver") or "2021.5.1"
 load(pathJoin("stack-intel-oneapi-mpi", stack_impi_ver))
+
+load("gnu")
+
 
 cmake_ver=os.getenv("cmake_ver") or "3.23.1"
 load(pathJoin("cmake", cmake_ver))


### PR DESCRIPTION
These changes were running with HFIP MPAS after the deprecation of lfs4.